### PR TITLE
Do not allow remote clients to spawn themselves before we're ready

### DIFF
--- a/src/network/mcpe/handler/PreSpawnPacketHandler.php
+++ b/src/network/mcpe/handler/PreSpawnPacketHandler.php
@@ -27,7 +27,6 @@ use pocketmine\data\bedrock\LegacyItemIdToStringIdMap;
 use pocketmine\network\mcpe\convert\RuntimeBlockMapping;
 use pocketmine\network\mcpe\NetworkSession;
 use pocketmine\network\mcpe\protocol\RequestChunkRadiusPacket;
-use pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket;
 use pocketmine\network\mcpe\protocol\StartGamePacket;
 use pocketmine\network\mcpe\protocol\types\DimensionIds;
 use pocketmine\network\mcpe\StaticPacketCache;
@@ -84,9 +83,6 @@ class PreSpawnPacketHandler extends PacketHandler{
 
 		$this->session->sendDataPacket(StaticPacketCache::getInstance()->getAvailableActorIdentifiers());
 		$this->session->sendDataPacket(StaticPacketCache::getInstance()->getBiomeDefs());
-
-		$this->player->setImmobile(); //HACK: fix client-side falling pre-spawn
-
 		$this->session->syncAttributes($this->player, $this->player->getAttributeMap()->getAll());
 		$this->session->syncAvailableCommands();
 		$this->session->syncAdventureSettings($this->player);
@@ -105,14 +101,6 @@ class PreSpawnPacketHandler extends PacketHandler{
 
 	public function handleRequestChunkRadius(RequestChunkRadiusPacket $packet) : bool{
 		$this->player->setViewDistance($packet->radius);
-
-		return true;
-	}
-
-	public function handleSetLocalPlayerAsInitialized(SetLocalPlayerAsInitializedPacket $packet) : bool{
-		$this->player->setImmobile(false); //HACK: this is set to prevent client-side falling before spawn
-
-		$this->session->onSpawn();
 
 		return true;
 	}

--- a/src/network/mcpe/handler/SpawnResponsePacketHandler.php
+++ b/src/network/mcpe/handler/SpawnResponsePacketHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\handler;
+
+use pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket;
+
+final class SpawnResponsePacketHandler extends PacketHandler{
+
+	/**
+	 * @var \Closure
+	 * @phpstan-var \Closure() : void
+	 */
+	private $responseCallback;
+
+	/**
+	 * @phpstan-param \Closure() : void $responseCallback
+	 */
+	public function __construct(\Closure $responseCallback){
+		$this->responseCallback = $responseCallback;
+	}
+
+	public function handleSetLocalPlayerAsInitialized(SetLocalPlayerAsInitializedPacket $packet) : bool{
+		($this->responseCallback)();
+		return true;
+	}
+}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -146,6 +146,7 @@ use pocketmine\network\mcpe\protocol\types\CommandEnum;
 use pocketmine\network\mcpe\protocol\types\CommandParameter;
 use pocketmine\network\mcpe\protocol\types\ContainerIds;
 use pocketmine\network\mcpe\protocol\types\DimensionIds;
+use pocketmine\network\mcpe\protocol\types\GameMode;
 use pocketmine\network\mcpe\protocol\types\PersonaPieceTintColor;
 use pocketmine\network\mcpe\protocol\types\PersonaSkinPiece;
 use pocketmine\network\mcpe\protocol\types\PlayerPermissions;
@@ -1333,12 +1334,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * TODO: remove this when Spectator Mode gets added properly to MCPE
 	 */
 	public static function getClientFriendlyGamemode(int $gamemode) : int{
-		$gamemode &= 0x03;
-		if($gamemode === Player::SPECTATOR){
-			return Player::CREATIVE;
-		}
-
-		return $gamemode;
+		static $map = [
+			self::SURVIVAL => GameMode::SURVIVAL,
+			self::CREATIVE => GameMode::CREATIVE,
+			self::ADVENTURE => GameMode::ADVENTURE,
+			self::SPECTATOR => GameMode::CREATIVE
+		];
+		return $map[$gamemode & 0x3];
 	}
 
 	/**

--- a/src/pocketmine/event/player/PlayerQuitEvent.php
+++ b/src/pocketmine/event/player/PlayerQuitEvent.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\event\player;
 
 use pocketmine\lang\TextContainer;
-use pocketmine\lang\TranslationContainer;
 use pocketmine\Player;
 
 /**

--- a/src/pocketmine/network/mcpe/NetworkBinaryStream.php
+++ b/src/pocketmine/network/mcpe/NetworkBinaryStream.php
@@ -37,6 +37,7 @@ use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\network\mcpe\protocol\types\CommandOriginData;
 use pocketmine\network\mcpe\protocol\types\EntityLink;
+use pocketmine\network\mcpe\protocol\types\GameRuleType;
 use pocketmine\network\mcpe\protocol\types\PersonaPieceTintColor;
 use pocketmine\network\mcpe\protocol\types\PersonaSkinPiece;
 use pocketmine\network\mcpe\protocol\types\SkinAnimation;
@@ -602,13 +603,13 @@ class NetworkBinaryStream extends BinaryStream{
 			$type = $this->getUnsignedVarInt();
 			$value = null;
 			switch($type){
-				case 1:
+				case GameRuleType::BOOL:
 					$value = $this->getBool();
 					break;
-				case 2:
+				case GameRuleType::INT:
 					$value = $this->getUnsignedVarInt();
 					break;
-				case 3:
+				case GameRuleType::FLOAT:
 					$value = $this->getLFloat();
 					break;
 			}
@@ -632,13 +633,13 @@ class NetworkBinaryStream extends BinaryStream{
 			$this->putString($name);
 			$this->putUnsignedVarInt($rule[0]);
 			switch($rule[0]){
-				case 1:
+				case GameRuleType::BOOL:
 					$this->putBool($rule[1]);
 					break;
-				case 2:
+				case GameRuleType::INT:
 					$this->putUnsignedVarInt($rule[1]);
 					break;
-				case 3:
+				case GameRuleType::FLOAT:
 					$this->putLFloat($rule[1]);
 					break;
 			}

--- a/src/pocketmine/network/mcpe/NetworkBinaryStream.php
+++ b/src/pocketmine/network/mcpe/NetworkBinaryStream.php
@@ -672,7 +672,7 @@ class NetworkBinaryStream extends BinaryStream{
 		$result->requestId = $this->getString();
 
 		if($result->type === CommandOriginData::ORIGIN_DEV_CONSOLE or $result->type === CommandOriginData::ORIGIN_TEST){
-			$result->varlong1 = $this->getVarLong();
+			$result->playerEntityUniqueId = $this->getVarLong();
 		}
 
 		return $result;
@@ -684,7 +684,7 @@ class NetworkBinaryStream extends BinaryStream{
 		$this->putString($data->requestId);
 
 		if($data->type === CommandOriginData::ORIGIN_DEV_CONSOLE or $data->type === CommandOriginData::ORIGIN_TEST){
-			$this->putVarLong($data->varlong1);
+			$this->putVarLong($data->playerEntityUniqueId);
 		}
 	}
 

--- a/src/pocketmine/network/mcpe/protocol/LoginPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/LoginPacket.php
@@ -35,8 +35,6 @@ use function json_decode;
 class LoginPacket extends DataPacket{
 	public const NETWORK_ID = ProtocolInfo::LOGIN_PACKET;
 
-	public const EDITION_POCKET = 0;
-
 	/** @var string */
 	public $username;
 	/** @var int */

--- a/src/pocketmine/network/mcpe/protocol/MoveActorAbsolutePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/MoveActorAbsolutePacket.php
@@ -33,6 +33,7 @@ class MoveActorAbsolutePacket extends DataPacket{
 
 	public const FLAG_GROUND = 0x01;
 	public const FLAG_TELEPORT = 0x02;
+	public const FLAG_FORCE_MOVE_LOCAL_ENTITY = 0x04;
 
 	/** @var int */
 	public $entityRuntimeId;

--- a/src/pocketmine/network/mcpe/protocol/MoveActorDeltaPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/MoveActorDeltaPacket.php
@@ -36,6 +36,9 @@ class MoveActorDeltaPacket extends DataPacket{
 	public const FLAG_HAS_ROT_X = 0x08;
 	public const FLAG_HAS_ROT_Y = 0x10;
 	public const FLAG_HAS_ROT_Z = 0x20;
+	public const FLAG_GROUND = 0x40;
+	public const FLAG_TELEPORT = 0x80;
+	public const FLAG_FORCE_MOVE_LOCAL_ENTITY = 0x100;
 
 	/** @var int */
 	public $entityRuntimeId;

--- a/src/pocketmine/network/mcpe/protocol/NpcRequestPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/NpcRequestPacket.php
@@ -30,6 +30,13 @@ use pocketmine\network\mcpe\NetworkSession;
 class NpcRequestPacket extends DataPacket{
 	public const NETWORK_ID = ProtocolInfo::NPC_REQUEST_PACKET;
 
+	public const REQUEST_SET_ACTIONS = 0;
+	public const REQUEST_EXECUTE_ACTION = 1;
+	public const REQUEST_EXECUTE_CLOSING_COMMANDS = 2;
+	public const REQUEST_SET_NAME = 3;
+	public const REQUEST_SET_SKIN = 4;
+	public const REQUEST_SET_INTERACTION_TEXT = 5;
+
 	/** @var int */
 	public $entityRuntimeId;
 	/** @var int */

--- a/src/pocketmine/network/mcpe/protocol/PlayerActionPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/PlayerActionPacket.php
@@ -49,7 +49,7 @@ class PlayerActionPacket extends DataPacket{
 	public const ACTION_STOP_GLIDE = 16;
 	public const ACTION_BUILD_DENIED = 17;
 	public const ACTION_CONTINUE_BREAK = 18;
-
+	public const ACTION_CHANGE_SKIN = 19;
 	public const ACTION_SET_ENCHANTMENT_SEED = 20;
 	public const ACTION_START_SWIMMING = 21;
 	public const ACTION_STOP_SWIMMING = 22;

--- a/src/pocketmine/network/mcpe/protocol/SimpleEventPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/SimpleEventPacket.php
@@ -32,6 +32,7 @@ class SimpleEventPacket extends DataPacket{
 
 	public const TYPE_ENABLE_COMMANDS = 1;
 	public const TYPE_DISABLE_COMMANDS = 2;
+	public const TYPE_UNLOCK_WORLD_TEMPLATE_SETTINGS = 3;
 
 	/** @var int */
 	public $eventType;

--- a/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
@@ -32,6 +32,7 @@ use pocketmine\network\mcpe\NetworkBinaryStream;
 use pocketmine\network\mcpe\NetworkSession;
 use pocketmine\network\mcpe\protocol\types\EducationEditionOffer;
 use pocketmine\network\mcpe\protocol\types\GeneratorType;
+use pocketmine\network\mcpe\protocol\types\MultiplayerGameVisibility;
 use pocketmine\network\mcpe\protocol\types\PlayerPermissions;
 use pocketmine\network\mcpe\protocol\types\RuntimeBlockMapping;
 use function count;
@@ -97,9 +98,9 @@ class StartGamePacket extends DataPacket{
 	/** @var bool */
 	public $hasLANBroadcast = true;
 	/** @var int */
-	public $xboxLiveBroadcastMode = 0; //TODO: find values
+	public $xboxLiveBroadcastMode = MultiplayerGameVisibility::FRIENDS_OF_FRIENDS;
 	/** @var int */
-	public $platformBroadcastMode = 0;
+	public $platformBroadcastMode = MultiplayerGameVisibility::FRIENDS_OF_FRIENDS;
 	/** @var bool */
 	public $commandsEnabled;
 	/** @var bool */

--- a/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
@@ -99,9 +99,9 @@ class StartGamePacket extends DataPacket{
 	/** @var bool */
 	public $hasLANBroadcast = true;
 	/** @var int */
-	public $xboxLiveBroadcastMode = MultiplayerGameVisibility::FRIENDS_OF_FRIENDS;
+	public $xboxLiveBroadcastMode = MultiplayerGameVisibility::PUBLIC;
 	/** @var int */
-	public $platformBroadcastMode = MultiplayerGameVisibility::FRIENDS_OF_FRIENDS;
+	public $platformBroadcastMode = MultiplayerGameVisibility::PUBLIC;
 	/** @var bool */
 	public $commandsEnabled;
 	/** @var bool */

--- a/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
@@ -30,6 +30,7 @@ use pocketmine\nbt\NetworkLittleEndianNBTStream;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\network\mcpe\NetworkBinaryStream;
 use pocketmine\network\mcpe\NetworkSession;
+use pocketmine\network\mcpe\protocol\types\GeneratorType;
 use pocketmine\network\mcpe\protocol\types\PlayerPermissions;
 use pocketmine\network\mcpe\protocol\types\RuntimeBlockMapping;
 use function count;
@@ -65,7 +66,7 @@ class StartGamePacket extends DataPacket{
 	/** @var int */
 	public $dimension;
 	/** @var int */
-	public $generator = 1; //default infinite - 0 old, 1 infinite, 2 flat
+	public $generator = GeneratorType::OVERWORLD;
 	/** @var int */
 	public $worldGamemode;
 	/** @var int */

--- a/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
@@ -31,6 +31,7 @@ use pocketmine\nbt\tag\ListTag;
 use pocketmine\network\mcpe\NetworkBinaryStream;
 use pocketmine\network\mcpe\NetworkSession;
 use pocketmine\network\mcpe\protocol\types\EducationEditionOffer;
+use pocketmine\network\mcpe\protocol\types\GameRuleType;
 use pocketmine\network\mcpe\protocol\types\GeneratorType;
 use pocketmine\network\mcpe\protocol\types\MultiplayerGameVisibility;
 use pocketmine\network\mcpe\protocol\types\PlayerPermissions;
@@ -110,7 +111,7 @@ class StartGamePacket extends DataPacket{
 	 * @phpstan-var array<string, array{0: int, 1: bool|int|float}>
 	 */
 	public $gameRules = [ //TODO: implement this
-		"naturalregeneration" => [1, false] //Hack for client side regeneration
+		"naturalregeneration" => [GameRuleType::BOOL, false] //Hack for client side regeneration
 	];
 	/** @var bool */
 	public $hasBonusChestEnabled = false;

--- a/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
@@ -30,6 +30,7 @@ use pocketmine\nbt\NetworkLittleEndianNBTStream;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\network\mcpe\NetworkBinaryStream;
 use pocketmine\network\mcpe\NetworkSession;
+use pocketmine\network\mcpe\protocol\types\EducationEditionOffer;
 use pocketmine\network\mcpe\protocol\types\GeneratorType;
 use pocketmine\network\mcpe\protocol\types\PlayerPermissions;
 use pocketmine\network\mcpe\protocol\types\RuntimeBlockMapping;
@@ -82,7 +83,7 @@ class StartGamePacket extends DataPacket{
 	/** @var int */
 	public $time = -1;
 	/** @var int */
-	public $eduEditionOffer = 0;
+	public $eduEditionOffer = EducationEditionOffer::NONE;
 	/** @var bool */
 	public $hasEduFeaturesEnabled = false;
 	/** @var float */

--- a/src/pocketmine/network/mcpe/protocol/UpdateBlockSyncedPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/UpdateBlockSyncedPacket.php
@@ -30,21 +30,25 @@ use pocketmine\network\mcpe\NetworkSession;
 class UpdateBlockSyncedPacket extends UpdateBlockPacket{
 	public const NETWORK_ID = ProtocolInfo::UPDATE_BLOCK_SYNCED_PACKET;
 
+	public const TYPE_NONE = 0;
+	public const TYPE_CREATE = 1;
+	public const TYPE_DESTROY = 2;
+
 	/** @var int */
 	public $entityUniqueId = 0;
 	/** @var int */
-	public $uvarint64_2 = 0;
+	public $updateType = 0;
 
 	protected function decodePayload(){
 		parent::decodePayload();
 		$this->entityUniqueId = $this->getUnsignedVarLong();
-		$this->uvarint64_2 = $this->getUnsignedVarLong();
+		$this->updateType = $this->getUnsignedVarLong();
 	}
 
 	protected function encodePayload(){
 		parent::encodePayload();
 		$this->putUnsignedVarLong($this->entityUniqueId);
-		$this->putUnsignedVarLong($this->uvarint64_2);
+		$this->putUnsignedVarLong($this->updateType);
 	}
 
 	public function handle(NetworkSession $session) : bool{

--- a/src/pocketmine/network/mcpe/protocol/UpdateBlockSyncedPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/UpdateBlockSyncedPacket.php
@@ -35,9 +35,9 @@ class UpdateBlockSyncedPacket extends UpdateBlockPacket{
 	public const TYPE_DESTROY = 2;
 
 	/** @var int */
-	public $entityUniqueId = 0;
+	public $entityUniqueId;
 	/** @var int */
-	public $updateType = 0;
+	public $updateType;
 
 	protected function decodePayload(){
 		parent::decodePayload();

--- a/src/pocketmine/network/mcpe/protocol/types/CommandOriginData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/CommandOriginData.php
@@ -48,5 +48,5 @@ class CommandOriginData{
 	public $requestId;
 
 	/** @var int */
-	public $varlong1;
+	public $playerEntityUniqueId;
 }

--- a/src/pocketmine/network/mcpe/protocol/types/EducationEditionOffer.php
+++ b/src/pocketmine/network/mcpe/protocol/types/EducationEditionOffer.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+final class EducationEditionOffer{
+
+	private function __construct(){
+		//NOOP
+	}
+
+	public const NONE = 0;
+	public const EVERYWHERE_EXCEPT_CHINA = 1;
+	public const CHINA = 2;
+}

--- a/src/pocketmine/network/mcpe/protocol/types/GameMode.php
+++ b/src/pocketmine/network/mcpe/protocol/types/GameMode.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+final class GameMode{
+
+	private function __construct(){
+		//NOOP
+	}
+
+	public const SURVIVAL = 0;
+	public const CREATIVE = 1;
+	public const ADVENTURE = 2;
+	public const SURVIVAL_VIEWER = 3;
+	public const CREATIVE_VIEWER = 4;
+	public const DEFAULT = 5;
+}

--- a/src/pocketmine/network/mcpe/protocol/types/GameRuleType.php
+++ b/src/pocketmine/network/mcpe/protocol/types/GameRuleType.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+final class GameRuleType{
+
+	private function __construct(){
+		//NOOP
+	}
+
+	public const BOOL = 1;
+	public const INT = 2;
+	public const FLOAT = 3;
+}

--- a/src/pocketmine/network/mcpe/protocol/types/GeneratorType.php
+++ b/src/pocketmine/network/mcpe/protocol/types/GeneratorType.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+final class GeneratorType{
+
+	private function __construct(){
+		//NOOP
+	}
+
+	public const FINITE_OVERWORLD = 0;
+	public const OVERWORLD = 1;
+	public const FLAT = 2;
+	public const NETHER = 3;
+	public const THE_END = 4;
+}

--- a/src/pocketmine/network/mcpe/protocol/types/MultiplayerGameVisibility.php
+++ b/src/pocketmine/network/mcpe/protocol/types/MultiplayerGameVisibility.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+final class MultiplayerGameVisibility{
+
+	private function __construct(){
+		//NOOP
+	}
+
+	public const NONE = 0;
+	public const INVITE = 1;
+	public const FRIENDS = 2;
+	public const FRIENDS_OF_FRIENDS = 3;
+	public const PUBLIC = 4;
+}

--- a/src/pocketmine/network/mcpe/protocol/types/UIProfile.php
+++ b/src/pocketmine/network/mcpe/protocol/types/UIProfile.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+final class UIProfile{
+
+	private function __construct(){
+		//NOOP
+	}
+
+	public const DESKTOP = 0;
+	public const MOBILE = 1;
+}

--- a/src/pocketmine/network/mcpe/protocol/types/UIProfile.php
+++ b/src/pocketmine/network/mcpe/protocol/types/UIProfile.php
@@ -29,6 +29,6 @@ final class UIProfile{
 		//NOOP
 	}
 
-	public const DESKTOP = 0;
-	public const MOBILE = 1;
+	public const CLASSIC = 0;
+	public const POCKET = 1;
 }

--- a/src/pocketmine/utils/Random.php
+++ b/src/pocketmine/utils/Random.php
@@ -94,8 +94,7 @@ class Random{
 		$this->x = $this->y;
 		$this->y = $this->z;
 		$this->z = $this->w;
-		$this->w = ($this->w ^ (($this->w >> 19) & 0x7fffffff)
-		                     ^ ($t ^ (($t >> 8) & 0x7fffffff))) & 0xffffffff;
+		$this->w = ($this->w ^ (($this->w >> 19) & 0x7fffffff) ^ ($t ^ (($t >> 8) & 0x7fffffff))) & 0xffffffff;
 
 		return $this->w;
 	}

--- a/src/pocketmine/utils/Terminal.php
+++ b/src/pocketmine/utils/Terminal.php
@@ -28,6 +28,7 @@ use function fopen;
 use function function_exists;
 use function getenv;
 use function is_array;
+use function sapi_windows_vt100_support;
 use function stream_isatty;
 
 abstract class Terminal{

--- a/tests/phpstan/configs/l8-baseline.neon
+++ b/tests/phpstan/configs/l8-baseline.neon
@@ -446,6 +446,11 @@ parameters:
 			path: ../../../src/network/mcpe/NetworkSession.php
 
 		-
+			message: "#^Cannot call method setImmobile\\(\\) on pocketmine\\\\player\\\\Player\\|null\\.$#"
+			count: 2
+			path: ../../../src/network/mcpe/NetworkSession.php
+
+		-
 			message: "#^Cannot call method doFirstSpawn\\(\\) on pocketmine\\\\player\\\\Player\\|null\\.$#"
 			count: 1
 			path: ../../../src/network/mcpe/NetworkSession.php


### PR DESCRIPTION
this would have allowed clients to send SetLocalPlayerAsInitializedPacket at any time during the spawn sequence, which would have caused undefined behaviour around spawning logic.